### PR TITLE
Handles only one file at a time to commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@
 language: go
 
 go:
-  - 1.4
+  - 1.6
   - tip
 
 install:
-  - wget https://dl.bintray.com/mitchellh/terraform/terraform_0.4.1_linux_amd64.zip
-  - unzip terraform_0.4.1_linux_amd64.zip
+  - wget https://codeload.github.com/hashicorp/terraform/zip/v0.6.16
+  - unzip terraform-0.6.16.zip
   - mkdir $HOME/gopath/bin
   - mv terraform* $HOME/gopath/bin 
   - go get

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
   - tip
 
 install:
-  - wget https://codeload.github.com/hashicorp/terraform/zip/v0.6.16
+  - wget https://codeload.github.com/hashicorp/terraform/zip/v0.6.16 --no-check-certificate -O terraform-0.6.16.zip
   - unzip terraform-0.6.16.zip
   - mkdir $HOME/gopath/bin
   - mv terraform* $HOME/gopath/bin 

--- a/yelppack/Dockerfile
+++ b/yelppack/Dockerfile
@@ -15,5 +15,7 @@ ENV PATH /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin:/usr/local
 ENV GOPATH /go
 RUN mkdir /go
 RUN gem install fpm
-
+RUN git clone https://github.com/yelp/terraform.git /go/src/github.com/hashicorp/terraform && \
+    cd /go/src/github.com/hashicorp/terraform && \
+        git checkout d7dc7c08eddf3b821650b284bdd1f77a02cb51c2
 #WORKDIR /go/src/github.com/Yelp/terraform-provider-gitfile

--- a/yelppack/Makefile
+++ b/yelppack/Makefile
@@ -1,8 +1,8 @@
 .PHONY: itest_% clean shell
 PROJECT = terraform-provider-gitfile
 
-VERSION = 0.4
-ITERATION = yelp5
+VERSION = 0.5
+ITERATION = yelp1
 ARCH := $(shell facter architecture)
 
 PACKAGE_NAME := $(PROJECT)_$(VERSION)-$(ITERATION)_$(ARCH).deb


### PR DESCRIPTION
This change makes gitfile_commit handle only 1 file at a time rather than list as it was doing before, but it seems to fix the error/crashes and makes it more stable.

This also bumps up the version.

Also the general use case of this is mostly involves changing a file and committing it, so this change should make things simpler.